### PR TITLE
Feature/update diff endpoint

### DIFF
--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -13,6 +13,7 @@ import { Role } from 'src/auth/enums/roles.enum';
 import { RolesGuard } from 'src/auth/roles.guard';
 import { User } from 'src/auth/user.entity';
 import { AdminService } from './admin.service';
+import { UpdateDiffDto } from './dto/update-diff.dto';
 
 @Controller('admin')
 @UseGuards(AuthGuard('jwt'), RolesGuard)
@@ -34,6 +35,10 @@ export class AdminController {
     usernames: string[],
   ) {
     return this.adminService.elimByUsername(usernames);
+  }
+  @Patch('/updateDiff')
+  updateRunDiff(@Body() updateDiffDto: UpdateDiffDto) {
+    return this.adminService.updateRunDiff(updateDiffDto);
   }
   @Delete('/deleteUser/:id')
   deleteUser(

--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -37,8 +37,8 @@ export class AdminController {
     return this.adminService.elimByUsername(usernames);
   }
   @Patch('/updateDiffByTeam')
-  updateRunDiff(@Body() updateDiffDto: UpdateDiffDto, user: User) {
-    return this.adminService.updateRunDiff(updateDiffDto, user);
+  updateRunDiff(@Body() updateDiffDto: UpdateDiffDto) {
+    return this.adminService.updateRunDiff(updateDiffDto);
   }
   @Delete('/deleteUser/:id')
   deleteUser(

--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -36,9 +36,9 @@ export class AdminController {
   ) {
     return this.adminService.elimByUsername(usernames);
   }
-  @Patch('/updateDiff')
-  updateRunDiff(@Body() updateDiffDto: UpdateDiffDto) {
-    return this.adminService.updateRunDiff(updateDiffDto);
+  @Patch('/updateDiffByTeam')
+  updateRunDiff(@Body() updateDiffDto: UpdateDiffDto, user: User) {
+    return this.adminService.updateRunDiff(updateDiffDto, user);
   }
   @Delete('/deleteUser/:id')
   deleteUser(

--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -43,7 +43,7 @@ export class AdminService {
     }
     return updateStatus;
   }
-  async updateRunDiff(updateDiffDto: UpdateDiffDto) {
+  async updateRunDiff(updateDiffDto: UpdateDiffDto, user: User) {
     console.log(updateDiffDto);
     const { week, team, diff } = updateDiffDto;
     const updateDiff = await this.picksRepository
@@ -52,12 +52,28 @@ export class AdminService {
       .set({ run_diff: diff })
       .where({ week: week })
       .andWhere({ pick: team })
+      .returning('"userId"')
       .execute();
-
+    console.log(updateDiff.raw);
     if (updateDiff.affected > 0) {
       Logger.log(
-        `${updateDiff.affected} Picks Run Differentials Updated!  Updating User Totals...`,
+        `${updateDiff.affected} Users Affected!  Updating User Totals...`,
       );
+      const userList = updateDiff.raw.map((x: { userId: string }) => x.userId);
+      const usersToUpdate = await this.picksRepository
+        .createQueryBuilder()
+        .where({ userId: In(userList) })
+        .andWhere({ week: updateDiffDto.week })
+        .execute();
+      console.log(usersToUpdate);
+      for (let x = 0; x < usersToUpdate.length; x++) {
+        await this.usersRepository
+          .createQueryBuilder()
+          .update(User)
+          .set({ diff: () => `diff + ${usersToUpdate[x].Picks_run_diff}` })
+          .where({ id: usersToUpdate[x].Picks_userId })
+          .execute();
+      }
     } else {
       Logger.warn('No user Diffs were updated!');
     }

--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -43,7 +43,7 @@ export class AdminService {
     }
     return updateStatus;
   }
-  async updateRunDiff(updateDiffDto: UpdateDiffDto, user: User) {
+  async updateRunDiff(updateDiffDto: UpdateDiffDto) {
     console.log(updateDiffDto);
     const { week, team, diff } = updateDiffDto;
     const updateDiff = await this.picksRepository

--- a/src/admin/dto/update-diff.dto.ts
+++ b/src/admin/dto/update-diff.dto.ts
@@ -1,0 +1,5 @@
+export class UpdateDiffDto {
+  team: string;
+  diff: number;
+  week: number;
+}

--- a/src/picks/picks.entity.ts
+++ b/src/picks/picks.entity.ts
@@ -1,7 +1,6 @@
 import { User } from '../auth/user.entity';
 import { Column, Entity, ManyToOne, PrimaryColumn } from 'typeorm';
 import { Exclude } from 'class-transformer';
-import { UUIDVersion } from 'class-validator';
 
 @Entity()
 export class Picks {

--- a/src/picks/picks.entity.ts
+++ b/src/picks/picks.entity.ts
@@ -1,6 +1,7 @@
 import { User } from '../auth/user.entity';
 import { Column, Entity, ManyToOne, PrimaryColumn } from 'typeorm';
 import { Exclude } from 'class-transformer';
+import { UUIDVersion } from 'class-validator';
 
 @Entity()
 export class Picks {
@@ -15,6 +16,9 @@ export class Picks {
 
   @Column({ nullable: true })
   run_diff: number;
+
+  @Column()
+  userId: string;
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   @ManyToOne((_type) => User, (user) => user.picks, { eager: false })

--- a/src/picks/picks.entity.ts
+++ b/src/picks/picks.entity.ts
@@ -13,6 +13,9 @@ export class Picks {
   @Column()
   pick: string;
 
+  @Column({ nullable: true })
+  run_diff: number;
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   @ManyToOne((_type) => User, (user) => user.picks, { eager: false })
   @Exclude({ toPlainOnly: true })


### PR DESCRIPTION
PR Allows for Run Differential to be updated at the team and user level.  
PROCESS:
- Admin sends a PATCH request containing the WEEK, TEAM (PICK), and the DIFF for each team.
- The PICKS table is updated with the DIFF (allows to monitor TEAM performance on a week-to-week basis)

<img width="877" alt="Screen Shot 2023-01-30 at 2 09 37 PM" src="https://user-images.githubusercontent.com/72280168/215572457-e4c8fa3d-fb3b-47cc-b1ec-85fec5bcfb3c.png">

Then, in same method, USERS table is sent the run diff and added on to the existing run diff as a running total and can be returned with the User Object.  

<img width="873" alt="Screen Shot 2023-01-30 at 2 10 16 PM" src="https://user-images.githubusercontent.com/72280168/215572671-2694d848-d5b2-47dc-a0ad-e6598952da12.png">

Will send updated postman collection with updated PATCH endpoint.
