### PR TITLE
logic for password resets

### DIFF
--- a/src/auth/dto/user-update.dto.ts
+++ b/src/auth/dto/user-update.dto.ts
@@ -1,5 +1,14 @@
+import { IsString, MinLength, MaxLength, Matches } from 'class-validator';
+
 export class UserUpdateDto {
   username?: string;
   email?: string;
+
+  @IsString()
+  @MinLength(8)
+  @MaxLength(32)
+  @Matches(/((?=.*\d)|(?=.*\W+))(?![.\n])(?=.*[A-Z])(?=.*[a-z]).*$/, {
+    message: 'password is too weak!',
+  })
   password?: string;
 }


### PR DESCRIPTION
Fixed logic where passwords were not being stored properly after user updates.  Reset passwords follow same restrictions as setting up a new one (Capital, Character length, special character)

- Also, changed find by parameters so id no longer required to find users (can be accessed by either email, username, or id)

Updating Password via email (assuming user cannot log in)
<img width="876" alt="Screen Shot 2023-02-13 at 10 07 06 PM" src="https://user-images.githubusercontent.com/72280168/218629478-60efcb32-59a8-4a27-aed6-4a1dbb122ea1.png">
<img width="784" alt="Screen Shot 2023-02-13 at 10 09 33 PM" src="https://user-images.githubusercontent.com/72280168/218629712-e27e7632-16ef-4180-baee-1ff8249838be.png">

Updating via username:
<img width="882" alt="Screen Shot 2023-02-13 at 10 09 02 PM 1" src="https://user-images.githubusercontent.com/72280168/218629709-4bc5e6de-b1e1-4e25-a87c-0f3da7b394c0.png">
<img width="704" alt="Screen Shot 2023-02-13 at 10 07 47 PM" src="https://user-images.githubusercontent.com/72280168/218629481-e18757ff-8bc2-44f1-bb48-43b867e87fb2.png">

--- Also tested locally.