### PR TITLE
dropped ID from update endpoint

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -33,11 +33,8 @@ export class AuthController {
   ): Promise<{ accessToken: string; refreshToken: string }> {
     return this.authService.login(authCredentialsDto);
   }
-  @Patch('/update/:id')
-  updateAccount(
-    @Param('id') id: string,
-    @Body() userUpdateDto: UserUpdateDto,
-  ): Promise<User> {
-    return this.authService.updateAccount(id, userUpdateDto);
+  @Patch('/update')
+  updateAccount(@Body() userUpdateDto: UserUpdateDto): Promise<User> {
+    return this.authService.updateAccount(userUpdateDto);
   }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -54,11 +54,11 @@ export class AuthService {
     }
   }
 
-  async updateAccount(id: string, userUpdateDto: UserUpdateDto): Promise<User> {
+  async updateAccount(userUpdateDto: UserUpdateDto): Promise<User> {
     const { username, email, password } = userUpdateDto;
     try {
       const userToUpdate = await this.usersRepository.findOne({
-        where: [{ id }, { email }, { username }],
+        where: [{ email }, { username }],
       });
       userToUpdate.username = username;
       userToUpdate.email = email;


### PR DESCRIPTION
Dropped ID param from update account endpoint so users can update account information without having to be logged in.
<img width="535" alt="Screen Shot 2023-02-14 at 10 53 08 PM" src="https://user-images.githubusercontent.com/72280168/218925033-676a6162-23d5-4210-a686-00c9ab2d52d2.png">
<img width="870" alt="Screen Shot 2023-02-14 at 10 53 30 PM" src="https://user-images.githubusercontent.com/72280168/218925043-88e453b9-40dd-4b0d-96c7-866d3430da7a.png">
