### PR TITLE
Feature/elim batch job configure

### DIFF
--- a/src/batch/batch.service.ts
+++ b/src/batch/batch.service.ts
@@ -85,8 +85,8 @@ export class BatchService {
    * TO DO: write logic where it can update every api update without aggregating diff
    * would allow for users to see run diffs update in real time.
    */
-  @Cron(CronExpression.EVERY_MINUTE, {
-    // @Cron('0 6 * * * ', {
+  // @Cron(CronExpression.EVERY_MINUTE, {
+  @Cron('0 6 * * * ', {
     name: 'user_diff_update',
     timeZone: 'America/New_York',
   })
@@ -115,11 +115,11 @@ export class BatchService {
   }
 
   /**
-   * UpdateUserStatus job runs once a week, 7am on Sundays
+   * UpdateUserStatus job runs once a week, 7am on Mondays
    * Checks user diff, if it's less than or equal to zero
    * set active to false
    */
-  @Cron('0 0 07 * * 1', {
+  @Cron('0 7 * * 1', {
     name: 'update_user_status',
     timeZone: 'America/New_York',
   })

--- a/src/batch/enum/jobType.enum.ts
+++ b/src/batch/enum/jobType.enum.ts
@@ -3,5 +3,6 @@ export enum JobType {
   email_status = 'user_email_status',
   daily_api_update = 'daily_api_update',
   daily_api_cleanup = 'daily_api_cleanup',
-  user_diff_update = 'weekly_diff_update',
+  user_diff_update = 'user_diff_update',
+  user_status_update = 'user_status_update',
 }

--- a/src/batch/enum/updateFlag.enum.ts
+++ b/src/batch/enum/updateFlag.enum.ts
@@ -1,0 +1,11 @@
+/**
+ * RUN_DIFF (Daily)= updates the users run differential at the league level
+ * STATUS (Weekly)= checks diff, if >= 0, set status to INACTIVE at league level
+ * PROFILE (Weekly)= updates career diff, weeks active, etc..
+ */
+
+export enum UpdateFlag {
+  diff = 'RUN_DIFF',
+  status = 'STATUS',
+  profile = 'PROFILE',
+}

--- a/src/league/league.controller.ts
+++ b/src/league/league.controller.ts
@@ -7,6 +7,7 @@ import {
   Param,
 } from '@nestjs/common';
 import { LeagueService } from './league.service';
+import { UpdateFlag } from '../batch/enum/updateFlag.enum';
 
 @Controller('league')
 export class LeagueController {
@@ -20,8 +21,11 @@ export class LeagueController {
     return this.leagueService.dailyLeagueUpdate(date, week);
   }
   @Post('/userUpdates')
-  updateUserDiffs(@Body('week', ParseIntPipe) week: number): Promise<string[]> {
-    return this.leagueService.updateUserDiffs(week);
+  updateUserDiffs(
+    @Body('week', ParseIntPipe) week: number,
+    updateFlag: UpdateFlag,
+  ): Promise<string[]> {
+    return this.leagueService.updateUserJobs(week, updateFlag);
   }
   @Get('/diffByTeam/:week/:team?')
   diffsByTeam(

--- a/src/league/league.repository.ts
+++ b/src/league/league.repository.ts
@@ -1,6 +1,7 @@
 import { EntityRepository, Repository } from 'typeorm';
 import { League } from './league.entity';
 import { Logger } from '@nestjs/common';
+import { UpdateFlag } from '../batch/enum/updateFlag.enum';
 
 @EntityRepository(League)
 export class LeagueRepository extends Repository<League> {
@@ -47,13 +48,21 @@ export class LeagueRepository extends Repository<League> {
     }
   }
 
-  async updateUserDiff(
+  async updateUsers(
+    /**
+     * Possible here to create an argument that delinates what type of update we're doing?
+     * Daily = update user diffs at the league level
+     * weekly = update user diffs and career numbers
+     * Could use different batch jobs to call the same method in the service.  Cuts down on clutter that way.
+     */
     diff: number,
     team: string,
     week: number,
     season: string,
+    updateFlag: UpdateFlag,
   ): Promise<void> {
     try {
+      // run this query no matter what.  Updates team scores/diffs.
       await this.query(
         `
             UPDATE picks
@@ -64,36 +73,36 @@ export class LeagueRepository extends Repository<League> {
             `,
         [diff, team, week, season],
       );
-      if (diff > 0) {
-        await this.query(
-          `
-          UPDATE public.user AS u
-          SET diff = diff + $1, 
-            career_diff = career_diff + $1
-          FROM picks AS p
-          WHERE p."userId" = u.id
-            AND u.isactive = true
-            AND p.pick = $2
-            AND p.week = $3
-            AND p.season = $4
-          `,
-          [diff, team, week, season],
-        );
-      } else {
-        await this.query(
-          `
-          UPDATE public.user AS u
-          SET diff = diff + $1, 
-            isactive = false, 
-            career_diff = career_diff + $1
-          FROM picks AS p
-          WHERE p."userId" = u.id
-            AND p.pick = $2
-            AND p.week = $3
-            AND p.season = $4
-          `,
-          [diff, team, week, season],
-        );
+      switch (updateFlag) {
+        case UpdateFlag.diff:
+          // runs once a day
+          await this.query(
+            `
+              UPDATE subleague_players as s
+              SET run_diff = s.run_diff + $1
+              FROM picks AS p
+              WHERE p."userId" = s."userId"
+                AND p.pick = $2
+                AND p.week = $3
+                AND p.season = $4
+              `,
+            [diff, team, week, season],
+          );
+          break;
+        case UpdateFlag.status:
+          // runs once a week
+          await this.query(
+            `
+            UPDATE subleague_players
+            SET active = false
+            WHERE run_diff >= 0
+            `,
+          );
+          break;
+        case UpdateFlag.profile:
+          break;
+        default:
+          Logger.warn('DEFAULT SWITCH CASE IN UPDATE FLAG');
       }
     } catch (error) {
       Logger.error(`Error updating user diff: ${error}`);

--- a/src/league/league.repository.ts
+++ b/src/league/league.repository.ts
@@ -100,6 +100,7 @@ export class LeagueRepository extends Repository<League> {
           );
           break;
         case UpdateFlag.profile:
+          // this will be added as a later feature
           break;
         default:
           Logger.warn('DEFAULT SWITCH CASE IN UPDATE FLAG');

--- a/src/league/league.service.ts
+++ b/src/league/league.service.ts
@@ -5,8 +5,8 @@ import { baseUrl, currentDayEndpoint } from '../utils/globals';
 import axios from 'axios';
 import { BatchRepository } from '../batch/batch.repository';
 import { season } from '../utils/globals';
-import { JobType } from '../batch/enum/jobType.enum';
 import { JobStatus } from '../batch/enum/jobStatus.enum';
+import { UpdateFlag } from '../batch/enum/updateFlag.enum';
 
 /**
  * Daily Update Status Codes:
@@ -74,7 +74,10 @@ export class LeagueService {
     }
   }
 
-  async updateUserDiffs(week: number): Promise<string[]> {
+  async updateUserJobs(
+    week: number,
+    updateFlag: UpdateFlag,
+  ): Promise<string[]> {
     try {
       const query = await this.leagueRepository.query(
         `
@@ -100,7 +103,13 @@ export class LeagueService {
       for (let q = 0; q < query.length; q++) {
         const team = query[q].team;
         const diff = query[q].diff;
-        await this.leagueRepository.updateUserDiff(diff, team, week, season);
+        await this.leagueRepository.updateUsers(
+          diff,
+          team,
+          week,
+          season,
+          updateFlag,
+        );
       }
       return query;
     } catch (error) {


### PR DESCRIPTION
Changed batch job configurations to do the following:
- Split UPDATE job into three cases:  Update run diff, update user status, update user profile (third needs work still)
- added enum to flag each cron job for appropriate SQL query
- set timings for each job

Tested locally.