### PR TITLE
added new batch job for weekly diff updates, realtime

### DIFF
--- a/src/batch/batch.service.ts
+++ b/src/batch/batch.service.ts
@@ -121,7 +121,7 @@ export class BatchService {
     try {
       const jobType = JobType.user_weekly_diff_update;
       const updateFlag = UpdateFlag.weekly_diff;
-      const date = format(endOfYesterday(), 'yyyy-LL-dd');
+      const date = format(subDays(new Date(), 1), 'yyyy-LL-dd');
       const week = await this.batchRepository.getWeekQuery(date);
       const weeklyUserUpdate = await this.leagueService.updateUserJobs(
         week,

--- a/src/batch/enum/jobType.enum.ts
+++ b/src/batch/enum/jobType.enum.ts
@@ -5,4 +5,5 @@ export enum JobType {
   daily_api_cleanup = 'daily_api_cleanup',
   user_diff_update = 'user_diff_update',
   user_status_update = 'user_status_update',
+  user_weekly_diff_update = 'user_weekly_diff_update',
 }

--- a/src/batch/enum/updateFlag.enum.ts
+++ b/src/batch/enum/updateFlag.enum.ts
@@ -5,7 +5,8 @@
  */
 
 export enum UpdateFlag {
-  diff = 'RUN_DIFF',
+  realtime_diff = 'RUN_DIFF',
+  weekly_diff = 'LEAGUE_DIFF',
   status = 'STATUS',
   profile = 'PROFILE',
 }

--- a/src/league/league.repository.ts
+++ b/src/league/league.repository.ts
@@ -74,7 +74,7 @@ export class LeagueRepository extends Repository<League> {
         [diff, team, week, season],
       );
       switch (updateFlag) {
-        case UpdateFlag.diff:
+        case UpdateFlag.realtime_diff:
           // runs once a day
           await this.query(
             `
@@ -99,8 +99,20 @@ export class LeagueRepository extends Repository<League> {
             `,
           );
           break;
-        case UpdateFlag.profile:
-          // this will be added as a later feature
+        case UpdateFlag.weekly_diff:
+          // runs once a week to update the users overall diff
+          await this.query(
+            `
+              UPDATE subleague_players as s
+              SET run_diff = s.run_diff + $1
+              FROM picks AS p
+              WHERE p."userId" = s."userId"
+                AND p.pick = $2
+                AND p.week = $3
+                AND p.season = $4
+              `,
+            [diff, team, week, season],
+          );
           break;
         default:
           Logger.warn('DEFAULT SWITCH CASE IN UPDATE FLAG');


### PR DESCRIPTION
ISSUE:
User diffs were out of sync from picks to subleague_players table, causing "overall" and "weekly" diffs to look different when they should be identical.

FIX:

- Separated diff update batch jobs into two, added new update flag
- one runs every 7 mins and just updates the "weekly diff" (picks table) based on whatever comes back from the API
- one runs once weekly on Mondays to take diff from previous week and add it to subleague_players table (as overall diff for league)