### PR TITLE
address build failures for jwtstrategy

### DIFF
--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -20,7 +20,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
 
   async validate(payload: JwtPayload): Promise<User> {
     const { id } = payload;
-    const user: User = await this.usersRepository.findOne({ id });
+    const user: any = await this.usersRepository.findOne({ id });
 
     if (!user) {
       throw new UnauthorizedException();


### PR DESCRIPTION
upgrading typeORM version created breaking change.  Solved locally by changing return type on JWT strategy.  Tested locally.